### PR TITLE
Create a centralized API Loader.

### DIFF
--- a/API/dinner.js
+++ b/API/dinner.js
@@ -22,13 +22,10 @@
      }
  };
 var c = require('irc-colors');
-var Google = require("./google");
-var config = require('../config.json');
 
 function Dinner(logger) {
     // Logger.
     this.log = logger.child({module: "Dinner API"});
-    this.google = new Google(config.google.apiKey, logger);
 }
 
 Dinner.prototype.getDinner = function(vegetarian, callback) {
@@ -58,7 +55,7 @@ Dinner.prototype.getDinner = function(vegetarian, callback) {
 Dinner.prototype.outputString = function(string, link, veg, callback) {
     var oS = string;
 
-    this.google.shorten_url(link, function(shortURL){
+    getClientManager().getAPI("Google").shorten_url(link, function(shortURL){
         oS += " (" + shortURL + ")";
         callback(oS);
     });

--- a/API/index.js
+++ b/API/index.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015  Austin Peterson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var DinnerAPI = require("./dinner");
+var GistAPI = require("./gist");
+var GitAPI = require("./git");
+var GoogleAPI = require("./google");
+var ImgurAPI = require("./imgur");
+var MALAPI = require("./mal");
+var RiotAPI = require("./riot");
+var SteamAPI = require("./steam");
+var XKCDAPI = require("./xkcd");
+var config = require("../config.json");
+
+/**
+ * Load all APIs.
+ * @param  {Logger} logger The logger to pass to loaded APIs.
+ * @return {Object}        The APIs.
+ */
+var loadAPIs = function(logger) {
+    var _log = logger.child({module: "API Loader"});
+    var APIs = {
+        Dinner: new DinnerAPI(logger),
+        Gist: {
+
+        },
+        Git: {
+
+        },
+        Google: {
+
+        },
+        Imgur: {
+
+        },
+        MAL: {
+
+        },
+        Riot: {
+
+        },
+        Steam: {
+
+        },
+        XKCD: {
+
+        }
+    };
+    return APIs;
+};
+
+module.exports = loadAPIs;

--- a/API/index.js
+++ b/API/index.js
@@ -41,9 +41,7 @@ var loadAPIs = function(logger) {
         Git: {
 
         },
-        Google: {
-
-        },
+        Google: new GoogleAPI(config.google.apiKey, logger),
         Imgur: {
 
         },

--- a/API/index.js
+++ b/API/index.js
@@ -35,28 +35,14 @@ var loadAPIs = function(logger) {
     var _log = logger.child({module: "API Loader"});
     var APIs = {
         Dinner: new DinnerAPI(logger),
-        Gist: {
-
-        },
-        Git: {
-
-        },
+        Gist: new GistAPI(logger),
+        Git: new GitAPI(logger),
         Google: new GoogleAPI(config.google.apiKey, logger),
-        Imgur: {
-
-        },
-        MAL: {
-
-        },
-        Riot: {
-
-        },
-        Steam: {
-
-        },
-        XKCD: {
-
-        }
+        Imgur: new ImgurAPI(config.imgur.clientID, logger),
+        MAL: new MALAPI(logger),
+        Riot: new RiotAPI(config.riot.apiKey, logger),
+        Steam: new SteamAPI(logger),
+        XKCD: new XKCDAPI(logger),
     };
     return APIs;
 };

--- a/API/steam.js
+++ b/API/steam.js
@@ -18,14 +18,10 @@
 var request = require('request-json');
 var c = require('irc-colors');
 var n = require('numeral');
-var Google = require("./google");
-var config = require('../config.json');
-
 function Steam(logger) {
     this.log = logger.child({module: "Steam API"});
     this.client = request.createClient('https://store.steampowered.com/');
     this.enhancedSteamAPI = request.createClient('http://api.enhancedsteam.com/');
-    this.google = new Google(config.google.apiKey, logger);
 }
 
 Steam.prototype.getGame = function(appId, callback, nohist, allStores) {
@@ -34,7 +30,6 @@ Steam.prototype.getGame = function(appId, callback, nohist, allStores) {
     self.appId = appId;
     self.callback = callback;
     self.enhancedSteamAPI = this.enhancedSteamAPI;
-    self.google = this.google;
     self.nohist = nohist;
 
     self.storeString = "&stores=steam";
@@ -147,7 +142,6 @@ Steam.prototype.getPkg = function(appId, callback, nohist) {
     self.appId = appId;
     self.callback = callback;
     self.enhancedSteamAPI = this.enhancedSteamAPI;
-    self.google = this.google;
     self.nohist = nohist;
 
     self.storeString = "&stores=steam";

--- a/AutoResponses/link.js
+++ b/AutoResponses/link.js
@@ -15,11 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var config = require('../config.json');
-var Steam = require('../API/steam');
-var Imgur = require('../API/imgur');
-var XKCDApi = require('../API/xkcd');
-var MALApi = require('../API/mal');
 var c = require('irc-colors');
 
 function LinkHandler(logger) {
@@ -55,18 +50,6 @@ function LinkHandler(logger) {
 
     //MAL regex
     this.MALRegex = require("../Regex/regex-mal");
-
-    //Steam API module.
-    this.steam = new Steam(logger);
-
-    //Imgur API module.
-    this.imgur = new Imgur(config.imgur.clientID, logger);
-
-    //XKCD API module.
-    this.XKCD = new XKCDApi(logger);
-
-    //MAL API module.
-    this.MAL = new MALApi(logger);
 
     //logger
     this.log = logger;
@@ -190,7 +173,7 @@ LinkHandler.prototype.SteamPackage = function(link, context) {
     var nohist = /nohist/i.exec(link);
     var allstores = /allstores/i.exec(link);
     if(id != null && noshow == null) {
-        this.steam.getPkg(id[1], function(res) {
+        getClientManager().getAPI("Steam").getPkg(id[1], function(res) {
             context.getClient().getIRCClient().say(context.getChannel().getName(), res);
         }, nohist, allstores);
     } else {
@@ -205,7 +188,7 @@ LinkHandler.prototype.SteamApp = function(link, context) {
     var nohist = /nohist/i.exec(link);
     var allstores = /allstores/i.exec(link);
     if(id != null && noshow == null) {
-        this.steam.getGame(id[1], function(res) {
+        getClientManager().getAPI("Steam").getGame(id[1], function(res) {
             context.getClient().getIRCClient().say(context.getChannel().getName(), res);
         }, nohist, allstores);
     } else {
@@ -227,7 +210,7 @@ LinkHandler.prototype.ImgurLink = function(link, context) {
         //id[1] == direct image.
         if(id[1]) {
             this.log.debug("Handling as direct image.");
-            this.imgur.getImageInfo(id[1], function(image) {
+            getClientManager().getAPI("Imgut").getImageInfo(id[1], function(image) {
                 if(image) {
                     context.getClient().getIRCClient().say(context.getChannel().getName(), self.constructImgurString(image));
                 }
@@ -241,7 +224,7 @@ LinkHandler.prototype.ImgurLink = function(link, context) {
                     //gallery image
                     this.log.debug("Handling as gallery image.");
                     if(info[0] == "gallery") {
-                        this.imgur.getGalleryInfo(info[1], function(image) {
+                        getClientManager().getAPI("Imgur").getGalleryInfo(info[1], function(image) {
                             if(image) {
                                 context.getClient().getIRCClient().say(context.getChannel().getName(), self.constructImgurString(image));
                             }
@@ -250,7 +233,7 @@ LinkHandler.prototype.ImgurLink = function(link, context) {
 
                     if(info[0] == "a") {
                         this.log.debug("Handling as album.");
-                        this.imgur.getAlbumInfo(info[1], function(image) {
+                        getClientManager().getAPI("Imgur").getAlbumInfo(info[1], function(image) {
                             if(image) {
                                 context.getClient().getIRCClient().say(context.getChannel().getName(), self.constructImgurString(image));
                             }
@@ -259,7 +242,7 @@ LinkHandler.prototype.ImgurLink = function(link, context) {
                 } else {
                     //if info is only one part, we know it has to be a direct image.
                     this.log.debug("Handling as direct image.");
-                    this.imgur.getImageInfo(info[0], function(image) {
+                    getClientManager().getAPI("Imgur").getImageInfo(info[0], function(image) {
                         if(image) {
                             context.getClient().getIRCClient().say(context.getChannel().getName(), self.constructImgurString(image));
                         }
@@ -313,7 +296,7 @@ LinkHandler.prototype.XKCDLink = function(link, context) {
     var noshow = /noinfo/i.exec(link);
     if(id != null) {
         if(noshow == null) {
-            this.XKCD.getComic(id[1], function(res){
+            getClientManager().getAPI("XKCD").getComic(id[1], function(res){
                 if(res){
                     context.getClient().getIRCClient().say(context.getChannel().getName(), res);
                 }
@@ -323,7 +306,7 @@ LinkHandler.prototype.XKCDLink = function(link, context) {
         }
     } else {
         if(this.XKCDRegex.homepage.exec(link) != null) {
-            this.XKCD.getLatestComic(function(res){
+            getClientManager().getAPI("XKCD").getLatestComic(function(res){
                 if(res) {
                     context.getClient().getIRCClient().say(context.getChannel().getName(), res);
                 }
@@ -333,7 +316,7 @@ LinkHandler.prototype.XKCDLink = function(link, context) {
 };
 
 LinkHandler.prototype.MALLink = function(link, context) {
-    this.MAL.getInfo(link, function(res){
+    getClientManager().getAPI("MAL").getInfo(link, function(res){
         context.getClient().getIRCClient().say(context.getChannel().getName(), res);
     });
 }

--- a/AutoResponses/link.js
+++ b/AutoResponses/link.js
@@ -16,7 +16,6 @@
  */
 
 var config = require('../config.json');
-var Google = require('../API/google');
 var Steam = require('../API/steam');
 var Imgur = require('../API/imgur');
 var XKCDApi = require('../API/xkcd');
@@ -56,9 +55,6 @@ function LinkHandler(logger) {
 
     //MAL regex
     this.MALRegex = require("../Regex/regex-mal");
-
-    //Google API module.
-    this.google = new Google(config.google.apiKey, logger);
 
     //Steam API module.
     this.steam = new Steam(logger);
@@ -179,7 +175,7 @@ LinkHandler.prototype.YouTubeVideo = function(link, context) {
     var id = this.youTubeRegex.exec(link);
     var noshow = /noinfo/i.exec(link);
     if(id != null && noshow == null) {
-        this.google.youtube_video_info(id[1], function(res){
+        getClientManager().getAPI("Google").youtube_video_info(id[1], function(res){
             context.getClient().getIRCClient().say(context.getChannel().getName(), res);
         });
     } else {

--- a/ClientManager.js
+++ b/ClientManager.js
@@ -32,7 +32,7 @@ function ClientManager(config, logger) {
     this.clients = [];
 
     // API objects.
-    this.APIs = require("./API/");
+    this.APIs = require("./API/")(logger);
 
     // load all of the clients on creation of this object.
     this.loadClients(config);

--- a/ClientManager.js
+++ b/ClientManager.js
@@ -31,6 +31,9 @@ function ClientManager(config, logger) {
     // array of all clients
     this.clients = [];
 
+    // API objects.
+    this.APIs = require("./API/");
+
     // load all of the clients on creation of this object.
     this.loadClients(config);
 
@@ -167,4 +170,12 @@ ClientManager.prototype.shutdown = function(msg) {
     }, 50);
 };
 
+/**
+ * Get an API instance.
+ * @param  {String} api_name The API to retrieve.
+ * @return {Object}          The API.
+ */
+ClientManager.prototype.getAPI = function(api_name) {
+    return (this.APIs[api_name] || null);
+};
 module.exports = ClientManager;

--- a/Commands/dinner.js
+++ b/Commands/dinner.js
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var DinnerAPI = require("../API/dinner");
-
 function Dinner(logger) {
     //the name of the command.
     this.name = "Dinner";
@@ -38,9 +36,6 @@ function Dinner(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //dinner api module.
-    this.dinnerAPI = new DinnerAPI(logger);
 }
 
 Dinner.prototype.execute = function(context) {
@@ -49,7 +44,7 @@ Dinner.prototype.execute = function(context) {
         veg = true;
     }
 
-    this.dinnerAPI.getDinner(veg, function(string) {
+    context.getClient().getClientManager().getAPI("Dinner").getDinner(veg, function(string) {
         context.getClient().say(context, string);
     })
 

--- a/Commands/geocode.js
+++ b/Commands/geocode.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var Google = require('../API/google');
-var config = require('../config.json');
-
 function Geocode(logger) {
     //the name of the command.
     this.name = "Geocode";
@@ -39,9 +36,6 @@ function Geocode(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //google API module for using Google APIs.
-    this.googleAPI = new Google(config.google.apiKey, logger);
 }
 
 Geocode.prototype.execute = function(context) {
@@ -63,7 +57,7 @@ Geocode.prototype.execute = function(context) {
         }
     }
 
-    this.googleAPI.geocode(location, region, function(msg){
+    getClientManager().getAPI("Google").geocode(location, region, function(msg){
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/git.js
+++ b/Commands/git.js
@@ -40,8 +40,6 @@ function Git(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    this._git = new (require("../API/git"))(logger);
 }
 
 Git.prototype.execute = function(context) {
@@ -58,7 +56,7 @@ Git.prototype.execute = function(context) {
             }
             var branch = args.splice(0,1)[0];
             var nick = context.getUser().getNick();
-            if (this._git.checkout(branch)) {
+            if (getClientManager().getAPI("Git").checkout(branch)) {
                 message = "Checked out ".append(branch);
             } else {
                 message = "Encountered an error while checking out ".append(branch);
@@ -68,7 +66,7 @@ Git.prototype.execute = function(context) {
             if (args.length) {
                 return false;
             }
-            if (this._git.fetch()) {
+            if (getClientManager().getAPI("Git").fetch()) {
                 message = "Fetched head";
             } else {
                 message = "Error while fetching head";

--- a/Commands/googl.js
+++ b/Commands/googl.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var Google = require('../API/google');
-var config = require('../config.json');
-
 function Googl(logger) {
     //the name of the command.
     this.name = "Goo.gl Link Shortener";
@@ -39,21 +36,18 @@ function Googl(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //google API module for using Google APIs.
-    this.googleAPI = new Google(config.google.apiKey, logger);
 }
 
 Googl.prototype.execute = function(context) {
     if(!context.arguments.length) {return false;}
-    this.googleAPI.shorten_url(context.arguments[0], function(url) {
+    getClientManager().getAPI("Google").shorten_url(context.arguments[0], function(url) {
         context.getClient().say(context, url);
     });
     return true;
 };
 
 Googl.prototype.shortenURL = function(context, url) {
-    this.googleAPI.shorten_url(url, function(url) {
+    getClientManager().getAPI("Google").shorten_url(url, function(url) {
         context.getClient().say(context, url);
     });
 };

--- a/Commands/googleimages.js
+++ b/Commands/googleimages.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var Google = require('../API/google');
-var config = require('../config.json');
-
 function GoogleImages(logger) {
     //the name of the command.
     this.name = "Google Images Search";
@@ -39,14 +36,11 @@ function GoogleImages(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //google API module for using Google APIs.
-    this.googleAPI = new Google(config.google.apiKey, logger);
 }
 
 GoogleImages.prototype.execute = function(context) {
     if(!context.arguments.length) {return false;}
-    this.googleAPI.search(context.arguments.join(" "), "images", function(msg) {
+    getClientManager().getAPI("Google").search(context.arguments.join(" "), "images", function(msg) {
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/googlesearch.js
+++ b/Commands/googlesearch.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var Google = require('../API/google');
-var config = require('../config.json');
-
 function GoogleSearch(logger) {
     //the name of the command.
     this.name = "Google Search";
@@ -39,14 +36,11 @@ function GoogleSearch(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //google API module for using Google APIs.
-    this.googleAPI = new Google(config.google.apiKey, logger);
 }
 
 GoogleSearch.prototype.execute = function(context) {
     if(!context.arguments.length) {return false;}
-    this.googleAPI.search(context.arguments.join(" "), "web", function(msg) {
+    getClientManager().getAPI("Google").search(context.arguments.join(" "), "web", function(msg) {
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/help.js
+++ b/Commands/help.js
@@ -16,8 +16,6 @@
  */
 
 var Gist = require('../API/gist');
-var Google = require('../API/google');
-var config = require('../config.json');
 
 function Help(logger) {
     //the name of the command.
@@ -43,9 +41,6 @@ function Help(logger) {
 
     //Gist API
     this.gistAPI = new Gist(logger);
-
-    //google API module for using Google APIs.
-    this.googleAPI = new Google(config.google.apiKey, logger);
 }
 
 Help.prototype.execute = function(context) {
@@ -114,7 +109,7 @@ Help.prototype.execute = function(context) {
         if(sendTo) {
             url += "#" + encodeURI(sendTo.toLowerCase().replace(/\s/g, "-"));
         }
-        self.googleAPI.shorten_url(url, function(url) {
+        getClientManager().getAPI("Google").shorten_url(url, function(url) {
             if(!context.getUser().isRealIRCUser) {
                 context.getClient().say(context, url);
             } else {

--- a/Commands/help.js
+++ b/Commands/help.js
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var Gist = require('../API/gist');
-
 function Help(logger) {
     //the name of the command.
     this.name = "Help";
@@ -38,9 +36,6 @@ function Help(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //Gist API
-    this.gistAPI = new Gist(logger);
 }
 
 Help.prototype.execute = function(context) {
@@ -97,7 +92,7 @@ Help.prototype.execute = function(context) {
     var self = this;
 
     //create gist of response
-    this.gistAPI.create({
+    getClientManager().getAPI("Gist").create({
         description: "Help for " + context.getClient().getNick(),
         files: {
             "help.md": {

--- a/Commands/js.js
+++ b/Commands/js.js
@@ -22,7 +22,6 @@ var request = require('request');
 var Chance = require('chance');
 var path = require('path');
 var fs = require('fs');
-var Gist = require('../API/gist');
 
 function Js(logger) {
     //the name of the command.
@@ -121,7 +120,7 @@ Js.prototype.runCode = function(code, context) {
         //if outputString is too long
         if(outputString.length > 350) {
             //upload Gist instead.
-            self.gistAPI.create({
+            getClientManager().getAPI("Gist").create({
                 description: "Output of JavaScript function for "+context.getUser().getNick(),
                 files: {
                     "_input.js": {

--- a/Commands/lmgtfy.js
+++ b/Commands/lmgtfy.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var Google = require('../API/google');
-var config = require('../config.json');
-
 function LMGTFY(logger) {
     //the name of the command.
     this.name = "LMGTFY";
@@ -39,15 +36,12 @@ function LMGTFY(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //google API module for using Google APIs.
-    this.googleAPI = new Google(config.google.apiKey, logger);
 }
 
 LMGTFY.prototype.execute = function(context) {
     var query = context.arguments.join(' ');
     query = encodeURIComponent(query);
-    this.googleAPI.shorten_url("http://lmgtfy.com/?q="+query, function(url) {
+    getClientManager().getAPI("Google").shorten_url("http://lmgtfy.com/?q="+query, function(url) {
         context.getClient().say(context, url);
     });
     return true;

--- a/Commands/lolfreechamps.js
+++ b/Commands/lolfreechamps.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var config = require('../config.json');
-var Riot = require('../API/riot');
-
 function LoLFreeChamps(logger) {
     //the name of the command.
     this.name = "LoL Free Champion Rotation";
@@ -39,13 +36,10 @@ function LoLFreeChamps(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //Riot API.
-    this.riotAPI = new Riot(config.riot.apiKey, logger);
 }
 
 LoLFreeChamps.prototype.execute = function(context) {
-    this.riotAPI.getFreeChamps(function(msg){
+    getClientManager().getAPI("Riot").getFreeChamps(function(msg){
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/lolserverstatus.js
+++ b/Commands/lolserverstatus.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var config = require('../config.json');
-var Riot = require('../API/riot');
-
 function LoLServerStatus(logger) {
     //the name of the command.
     this.name = "LoL Server Status";
@@ -39,15 +36,12 @@ function LoLServerStatus(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //Riot API.
-    this.riotAPI = new Riot(config.riot.apiKey, logger);
 }
 
 LoLServerStatus.prototype.execute = function(context) {
     var region = "na";
     if(context.arguments[0]) {region = context.arguments[0];}
-    this.riotAPI.getServerStatus(region, function(msg) {
+    getClientManager().getAPI("Riot").getServerStatus(region, function(msg) {
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/qr.js
+++ b/Commands/qr.js
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var config = require('../config.json');
-var Imgur = require('../API/imgur');
-
 function QR(logger) {
     //the name of the command.
     this.name = "QR Code";
@@ -42,9 +39,6 @@ function QR(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
-
-    //imgur API
-    this.imgurAPI = new Imgur(config.imgur.clientID, logger);
 }
 
 QR.prototype.execute = function(context) {
@@ -55,7 +49,7 @@ QR.prototype.execute = function(context) {
     var imageURL = "http://chart.googleapis.com/chart?cht=qr&chs=500x500&chl=" + encodeURIComponent(context.arguments.join(" "));
 
     //upload the image to imgur
-    this.imgurAPI.uploadImageFromURL(imageURL, function (url) {
+    getClientManager().getAPI("Imgur")..uploadImageFromURL(imageURL, function (url) {
         if(url) {
             context.getClient().getCommandProcessor().aliasedCommands['googl'].shortenURL(context, url);
         } else {

--- a/Commands/version.js
+++ b/Commands/version.js
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var Git = require("../API/git");
-
 function Version(logger) {
     //the name of the command.
     this.name = "Version";
@@ -42,9 +40,6 @@ function Version(logger) {
     // Base version
     this.version_base = require('../package.json').version;
 
-    //Git API
-    this.git = new Git(logger);
-
     this.version = this.buildVersion();
 }
 
@@ -59,7 +54,7 @@ Version.prototype.execute = function(context) {
 
 Version.prototype.buildVersion = function() {
     var version = this.version_base;
-    var git = this.git;
+    var git = getClientManager().getAPI("Git").;
     if (git.isRepo()) {
         var gitSHA = git.getCommit().substring(0, 7);
         var tagOrBranch = git.getBranch() || git.getTag();

--- a/server.js
+++ b/server.js
@@ -53,6 +53,10 @@ require('./polyfill.js')(log);
 log.info("Creating Client Manager.");
 var clientmanager = new ClientManager(config, log);
 
+GLOBAL.getClientManager = function() {
+    return clientmanager;
+}
+
 //todo: better exception handling plz
 if(config.productionMode) {
     process.on('uncaughtException', function(err) {


### PR DESCRIPTION
Allows us to use API modules only once, resulting in less calls to the same things because we have 2 of the same API loaded.