### PR TITLE
Add caching.

### DIFF
--- a/Commands/googl.js
+++ b/Commands/googl.js
@@ -36,18 +36,37 @@ function Googl(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
+
+    //cache
+    this.cache = new (require('../lib/cache'))(logger);
 }
 
 Googl.prototype.execute = function(context) {
     if(!context.arguments.length) {return false;}
+    var self = this;
+    var cachedResponse = this.cache.getCached(("Googl"+context.arguments[0]).sha1());
+    if(cachedResponse) {
+        context.getClient().say(context, cachedResponse);
+        return true;
+    }
     getClientManager().getAPI("Google").shorten_url(context.arguments[0], function(url) {
+        var cacheExpire = (Date.now() / 1000 | 0) + 1576800000; //make cache expire in 50 years
+        self.cache.addToCache(("Googl"+context.arguments[0]).sha1(), url, cacheExpire);
         context.getClient().say(context, url);
     });
     return true;
 };
 
 Googl.prototype.shortenURL = function(context, url) {
+    var self = this;
+    var cachedResponse = this.cache.getCached(("Googl"+url).sha1());
+    if(cachedResponse) {
+        context.getClient().say(context, cachedResponse);
+        return true;
+    }
     getClientManager().getAPI("Google").shorten_url(url, function(url) {
+        var cacheExpire = (Date.now() / 1000 | 0) + 1576800000; //make cache expire in 50 years
+        self.cache.addToCache(("Googl"+url).sha1(), url, cacheExpire);
         context.getClient().say(context, url);
     });
 };

--- a/Commands/googleimages.js
+++ b/Commands/googleimages.js
@@ -36,11 +36,22 @@ function GoogleImages(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
+
+    //cache
+    this.cache = new (require('../lib/cache'))(logger);
 }
 
 GoogleImages.prototype.execute = function(context) {
     if(!context.arguments.length) {return false;}
+    var self = this;
+    var cachedResponse = this.cache.getCached(("GoogleImages"+context.arguments.join(" ")).sha1());
+    if(cachedResponse) {
+        context.getClient().say(context, cachedResponse);
+        return true;
+    }
     getClientManager().getAPI("Google").search(context.arguments.join(" "), "images", function(msg) {
+        var cacheExpire = (Date.now() / 1000 | 0) + 86400; //make cache expire in 1 day
+        self.cache.addToCache(("GoogleImages"+context.arguments.join(" ")).sha1(), msg, cacheExpire);
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/googlesearch.js
+++ b/Commands/googlesearch.js
@@ -36,11 +36,22 @@ function GoogleSearch(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
+
+    //cache
+    this.cache = new (require('../lib/cache'))(logger);
 }
 
 GoogleSearch.prototype.execute = function(context) {
     if(!context.arguments.length) {return false;}
+    var self = this;
+    var cachedResponse = this.cache.getCached(("GoogleSearch"+context.arguments.join(" ")).sha1());
+    if(cachedResponse) {
+        context.getClient().say(context, cachedResponse);
+        return true;
+    }
     getClientManager().getAPI("Google").search(context.arguments.join(" "), "web", function(msg) {
+        var cacheExpire = (Date.now() / 1000 | 0) + 86400; //make cache expire in 1 day
+        self.cache.addToCache(("GoogleSearch"+context.arguments.join(" ")).sha1(), msg, cacheExpire);
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/lolfreechamps.js
+++ b/Commands/lolfreechamps.js
@@ -36,10 +36,21 @@ function LoLFreeChamps(logger) {
 
     //whether or not to only allow this command if it's in a private message.
     this.isPmOnly = false;
+
+    //cache
+    this.cache = new (require('../lib/cache'))(logger);
 }
 
 LoLFreeChamps.prototype.execute = function(context) {
+    var self = this;
+    var cachedResponse = this.cache.getCached(("RitoPlsGiveMeFreeChamps").sha1());
+    if(cachedResponse) {
+        context.getClient().say(context, cachedResponse);
+        return true;
+    }
     getClientManager().getAPI("Riot").getFreeChamps(function(msg){
+        var cacheExpire = (Date.now() / 1000 | 0) + 1800; //make cache expire in 30 minutes
+        self.cache.addToCache(("RitoPlsGiveMeFreeChamps").sha1(), msg, cacheExpire);
         context.getClient().say(context, msg);
     });
     return true;

--- a/Commands/mcnamehistory.js
+++ b/Commands/mcnamehistory.js
@@ -49,6 +49,7 @@ MCNameHistory.prototype.execute = function(context) {
 
     //TODO: make this follow redirects.
     //TODO: make this just generally work better. (show previous times and things of that nature.)
+    //TODO: cacheing.
     //Example names to use: PlasmaPod, ezfe.
 
     context.apiClient.get("/users/profiles/minecraft/"+context.name, function(err, res, body) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015  Austin Peterson
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+function Cache(logger) {
+    this.cache = {};
+
+    // Logger.
+    this.log = logger.child({module: "Cache"});
+}
+
+Cache.prototype.addToCache = function(key, data, expires) {
+    if(typeof expires != "number") {
+        this.log.trace({key: key, reason: "expires is not a number."}, "Not added to cache.");
+        return false;
+    }
+    if(expires <= (Date.now() / 1000 | 0)) {
+        this.log.trace({key: key, reason:"expires is in the past."}, "Not added to cache.");
+        return false;
+    }
+    this.log.trace({key: key, data: data, expires: expires}, "Added to cache.");
+    this.cache[key] = {data: data, expires: expires};
+    return true;
+};
+
+Cache.prototype.getCached = function(key) {
+    if(!this.cache[key]) {
+        this.log.trace({key: key}, "Cache miss.");
+        return undefined;
+    }
+
+    if(this.cache[key].expires < (Date.now() / 1000 | 0)) {
+        this.log.trace({key: key, data: this.cache[key].data, expires: this.cache[key].expires}, "Removed from cache.");
+        delete this.cache[key];
+        return undefined;
+    }
+
+    this.log.trace({key: key, data: this.cache[key].data, expires: this.cache[key].expires}, "Fetched from cache.");
+    return this.cache[key].data;
+};
+
+module.exports = Cache;

--- a/polyfill.js
+++ b/polyfill.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+var crypto = require('crypto');
+
 function Polyfill(logger) {
   var log = logger.child({module: "Polyfill"});
 
@@ -76,6 +78,13 @@ function Polyfill(logger) {
     String.prototype.append = function(text) {
       var str = this.toString();
       return str ? str+text : str;
+    }
+  }
+
+  if (!String.prototype.sha1) {
+    log.trace("String.prototype.sha1 not found. Adding...");
+    String.prototype.sha1 = function() {
+      return crypto.createHash('sha1').update(this.toString()).digest('hex');
     }
   }
 


### PR DESCRIPTION
Nearly everything that uses an external API is cached now, so we won't
need to send out so many requests, and hopefully we'll notice a speedup in
some places.